### PR TITLE
Fixed Issue #1, Duplicate Code for t and vr.

### DIFF
--- a/src/Mnemonics/CSharp.fs
+++ b/src/Mnemonics/CSharp.fs
@@ -83,6 +83,24 @@ let cSharpStructureTemplates =
     )
   ]
 
+let cSharpUntypedMemberTemplates =
+  [
+    (
+      "tm",
+      [
+        Text "A test method."
+      ],
+      [
+        Text "[Test] public void "
+        Constant ("methodname", "MyMethod")
+        Text "()"
+        Scope [
+          endConstant
+        ]
+      ]
+    )
+  ]
+
 let cSharpMemberTemplates =
   [
     (
@@ -107,7 +125,7 @@ let cSharpMemberTemplates =
       ],
       [
         Text "private readonly "
-        Constant ("type", "type")
+        FixedType
         Text " "
         Constant ("fieldname", "fieldname")
         semiColon
@@ -159,20 +177,6 @@ let cSharpMemberTemplates =
         Text " = "
         DefaultValue
         semiColon
-      ]
-    )
-    (
-      "t",
-      [
-        Text "A test method."
-      ],
-      [
-        Text "[Test] public void "
-        Constant ("methodname", "MyMethod")
-        Text "()"
-        Scope [
-          endConstant
-        ]
       ]
     )
     (

--- a/src/Mnemonics/Program.fs
+++ b/src/Mnemonics/Program.fs
@@ -111,6 +111,19 @@ let renderReSharper() =
 
   // now process members
   if renderCSharp then
+    for (s,doc,exprs) in cSharpUntypedMemberTemplates do
+      let t = new TemplatesExportTemplate(shortcut=s)
+      let vars = new List<TemplatesExportTemplateVariable>()
+      t.description <- printExpressions doc vars String.Empty
+      t.reformat <- "True"
+      t.uid <- newGuid()
+      t.text <- printExpressions exprs vars String.Empty
+
+      t.Context <- new TemplatesExportTemplateContext(CSharpContext = csContext)
+      t.Variables <- vars.ToArray()
+      templates.Add t
+    done
+
     for (s,doc,exprs) in cSharpMemberTemplates do
       // simple types; methods can be void
       let types = (if Char.ToLower(s.Chars(0)) ='m' then ("", "void", "") :: csharpTypes else csharpTypes)
@@ -166,6 +179,18 @@ let renderReSharper() =
     done
 
   if renderVBNET then
+    for (s,doc,exprs) in vbUntypedMemberTemplates do
+      let t = new TemplatesExportTemplate(shortcut=s)
+      let vars = new List<TemplatesExportTemplateVariable>()
+      t.description <- printExpressions doc vars String.Empty
+      t.reformat <- "False" // critical difference with C#!!!
+      t.uid <- newGuid()
+      t.text <- printExpressions exprs vars String.Empty
+      t.Context <- new TemplatesExportTemplateContext(VBContext = vbContext)
+      t.Variables <- vars.ToArray()
+      templates.Add t
+    done
+
     for (s,doc,exprs) in vbMemberTemplates do
       // simple types; methods can be void
       for (tk,tv,defValue) in vbTypes do

--- a/src/Mnemonics/VB.NET.fs
+++ b/src/Mnemonics/VB.NET.fs
@@ -71,6 +71,21 @@ let vbStructureTemplates =
     )
   ]
 
+let vbUntypedMemberTemplates =
+  [
+    (
+      "tm",
+      [
+        Text "A test method."
+      ],
+      [
+        Text "<Test> Public Sub "
+        Constant ("methodname", "SomeMethod")
+        Text "()"
+      ]
+    )
+  ]
+
 let vbMemberTemplates =
   [
     (
@@ -142,17 +157,6 @@ let vbMemberTemplates =
         FixedType
         Text " = "
         DefaultValue
-      ]
-    )
-    (
-      "t",
-      [
-        Text "A test method."
-      ],
-      [
-        Text "<Test> Public Sub "
-        Constant ("methodname", "SomeMethod")
-        Text "()"
       ]
     )
     (


### PR DESCRIPTION
Fixed the issue with vr templates replicating, rather than getting the type definitions.
Moved the t templates to a new UntypedMemberTemplates group, as the test templates will not be appended with type definitions. Also, renamed the template from t to tm (Test Method) to allow for future test fixture, setup, and teardown templates.

Did not regenerate the Download files.
